### PR TITLE
Test node sync on startup

### DIFF
--- a/fixtures/certs.sh
+++ b/fixtures/certs.sh
@@ -5,7 +5,7 @@ OUT=$(dirname -- "${BASH_SOURCE[0]}")
 openssl req -x509 -new -nodes -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 -days 1 \
 	-keyout $OUT/ca.key -out $OUT/ca.crt \
 	-subj "/C=GB/ST=London/L=London/O=etcdmon/CN=etcd-ca" -addext "subjectAltName=DNS:etcd-ca" 
-for i in $(seq 3); do
+for i in $(seq 4); do
 	rm -rf $OUT/$i/
 	mkdir -p $OUT/$i
 	cp $OUT/ca.{key,crt} $OUT/$i/

--- a/fixtures/kind.yaml
+++ b/fixtures/kind.yaml
@@ -28,3 +28,11 @@ nodes:
   extraPortMappings:
   - containerPort: 2379
     hostPort: 5003
+- role: control-plane
+  image: etcdmon-test
+  extraMounts:
+  - hostPath: ./fixtures/4/
+    containerPath: /etc/kubernetes/pki/etcd
+  extraPortMappings:
+  - containerPort: 2379
+    hostPort: 5004

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
           pname = "etcdmon";
           version = "0.0.1";
           src = ./.;
-          vendorSha256 = "sha256-iNhypHbBn1alB5LE5uOq8PwbhfwkcR9fs1P4xa6MYYs=";
+          vendorSha256 = "sha256-bpOGmgr9eA1OePFicmBviUWc30g9d37ocgljL1zcYAI=";
 
           checkInputs = [ pkgs.kind ];
         };

--- a/main.go
+++ b/main.go
@@ -64,12 +64,8 @@ func reconcile(k8s *K8sClient, etcd *EtcdClient) error {
 	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-	if err := etcd.Sync(ctx); err != nil {
-		return err
-	}
-	cancel()
-
-	return nil
+	defer cancel()
+	return etcd.Sync(ctx)
 }
 
 func main() {
@@ -101,7 +97,7 @@ func main() {
 
 	ch := make(chan struct{})
 	go k8sClient.WatchNodes(ch)
-	for _ = range ch {
+	for range ch {
 		if err := reconcile(k8sClient, etcdClient); err != nil {
 			panic(err.Error())
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -39,7 +39,64 @@ func TestMain(m *testing.M) {
 }
 
 func TestKubernetes(t *testing.T) {
-	f1 := features.New("node deletion").
+	var etcd *EtcdClient
+	var nodes corev1.NodeList
+
+	sync := features.New("node sync").
+		WithSetup("etcd client", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client := cfg.Client()
+			err := wait.For(conditions.New(client.Resources()).ResourceListN(
+				&nodes, nNodes, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"node-role.kubernetes.io/control-plane": ""})),
+			), wait.WithTimeout(3*time.Minute))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Configured in kind.yaml
+			etcdEndpoints := make([]string, 0, nNodes)
+			for p := 5001; p < 5001+nNodes; p++ {
+				etcdEndpoints = append(etcdEndpoints, fmt.Sprintf("127.0.0.1:%d", p))
+			}
+			etcdCerts := CertPaths{
+				caCert:     "./fixtures/ca.crt",
+				clientCert: "./fixtures/ca.crt",
+				clientKey:  "./fixtures/ca.key",
+			}
+			etcdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			etcd, err = NewEtcd(etcdEndpoints, etcdCerts, etcdCtx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			members, err := etcd.MemberList(etcdCtx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cancel()
+			if len(members.Members) != nNodes {
+				t.Fatalf("Wrong number of initial etcd members: %d != %d", len(members.Members), nNodes)
+			}
+			return ctx
+		}).
+		WithSetup("delete node", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client := cfg.Client()
+			deletedNode := nodes.Items[0]
+			err := cfg.Client().Resources().Delete(context.TODO(), &deletedNode)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Try twice, to give the load-balancer a chance to detect the downed node
+			for i := 0; i < 2; i++ {
+				err = wait.For(conditions.New(client.Resources()).ResourceDeleted(&deletedNode), wait.WithTimeout(time.Minute*1))
+				if err == nil {
+					break
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).
 		WithSetup("install etcdmon", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client := cfg.Client()
 
@@ -118,42 +175,24 @@ func TestKubernetes(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("etcd removed on node deletion", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			client := cfg.Client()
-			var nodes corev1.NodeList
-			err := wait.For(conditions.New(client.Resources()).ResourceListN(
-				&nodes, nNodes, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"node-role.kubernetes.io/control-plane": ""})),
-			), wait.WithTimeout(3*time.Minute))
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Configured in kind.yaml
-			etcdEndpoints := make([]string, 0, 4)
-			for p := 5001; p < 5001+nNodes; p++ {
-				etcdEndpoints = append(etcdEndpoints, fmt.Sprintf("127.0.0.1:%d", p))
-			}
-			etcdCerts := CertPaths{
-				caCert:     "./fixtures/ca.crt",
-				clientCert: "./fixtures/ca.crt",
-				clientKey:  "./fixtures/ca.key",
-			}
+		Assess("etcd removed on startup", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			etcdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			etcd, err := NewEtcd(etcdEndpoints, etcdCerts, etcdCtx)
-			if err != nil {
-				t.Fatal(err)
-			}
 			members, err := etcd.MemberList(etcdCtx)
+			cancel()
 			if err != nil {
 				t.Fatal(err)
 			}
-			cancel()
-			if len(members.Members) != nNodes {
-				t.Fatalf("Wrong number of initial etcd members: %d != %d", len(members.Members), nNodes)
+			if len(members.Members) != nNodes-1 {
+				t.Fatalf("Wrong number of final etcd members: %d != %d", len(members.Members), nNodes-1)
 			}
+			return ctx
+		}).Feature()
 
-			deletedNode := nodes.Items[0]
-			err = cfg.Client().Resources().Delete(context.TODO(), &nodes.Items[0])
+	deletion := features.New("node deletion").
+		WithSetup("delete node", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			client := cfg.Client()
+			deletedNode := nodes.Items[1]
+			err := cfg.Client().Resources().Delete(context.TODO(), &deletedNode)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -168,19 +207,20 @@ func TestKubernetes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			etcdCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
-			members, err = etcd.MemberList(etcdCtx)
+			return ctx
+		}).
+		Assess("etcd removed on node deletion", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			etcdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			members, err := etcd.MemberList(etcdCtx)
 			cancel()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(members.Members) != nNodes-1 {
-				t.Fatalf("Wrong number of final etcd members: %d != %d", len(members.Members), nNodes-1)
+			if len(members.Members) != nNodes-2 {
+				t.Fatalf("Wrong number of final etcd members: %d != %d", len(members.Members), nNodes-2)
 			}
-
 			return ctx
 		}).Feature()
 
-	testenv.Test(t, f1)
+	testenv.Test(t, sync, deletion)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
+const nNodes = 4
+
 var testenv env.Environment
 
 func TestMain(m *testing.M) {
@@ -38,7 +40,7 @@ func TestMain(m *testing.M) {
 
 func TestKubernetes(t *testing.T) {
 	f1 := features.New("node deletion").
-		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		WithSetup("install etcdmon", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			client := cfg.Client()
 
 			name := "etcdmon"
@@ -49,7 +51,7 @@ func TestKubernetes(t *testing.T) {
 				Rules: []rbacv1.PolicyRule{{
 					APIGroups: []string{""},
 					Resources: []string{"pods"},
-					Verbs:     []string{"get", "list"},
+					Verbs:     []string{"get", "list", "watch"},
 				}, {
 					APIGroups: []string{""},
 					Resources: []string{"nodes"},
@@ -120,22 +122,15 @@ func TestKubernetes(t *testing.T) {
 			client := cfg.Client()
 			var nodes corev1.NodeList
 			err := wait.For(conditions.New(client.Resources()).ResourceListN(
-				&nodes, 3, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"node-role.kubernetes.io/control-plane": ""})),
-			), wait.WithTimeout(3 * time.Minute))
-			if err != nil {
-				t.Fatal(err)
-			}
-			var pods corev1.PodList
-			err = wait.For(conditions.New(client.Resources()).ResourceListN(
-				&pods, 3, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"component": "etcd", "tier": "control-plane"})),
-			), wait.WithTimeout(1 * time.Minute))
+				&nodes, nNodes, resources.WithLabelSelector(labels.FormatLabels(map[string]string{"node-role.kubernetes.io/control-plane": ""})),
+			), wait.WithTimeout(3*time.Minute))
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Configured in kind.yaml
-			etcdEndpoints := make([]string, 0, 3)
-			for p := 5001; p <= 5003; p++ {
+			etcdEndpoints := make([]string, 0, 4)
+			for p := 5001; p < 5001+nNodes; p++ {
 				etcdEndpoints = append(etcdEndpoints, fmt.Sprintf("127.0.0.1:%d", p))
 			}
 			etcdCerts := CertPaths{
@@ -153,24 +148,11 @@ func TestKubernetes(t *testing.T) {
 				t.Fatal(err)
 			}
 			cancel()
-			if len(members.Members) != 3 {
-				t.Fatalf("Wrong number of etcd members: %d != 3", len(members.Members))
+			if len(members.Members) != nNodes {
+				t.Fatalf("Wrong number of initial etcd members: %d != %d", len(members.Members), nNodes)
 			}
 
 			deletedNode := nodes.Items[0]
-			deletedPods := make([]corev1.Pod, 0, 1)
-			survivingPods := make([]corev1.Pod, 0, len(pods.Items)-1)
-			for _, pod := range pods.Items {
-				if pod.Spec.NodeName == deletedNode.ObjectMeta.Name {
-					deletedPods = append(deletedPods, pod)
-				} else {
-					survivingPods = append(survivingPods, pod)
-				}
-			}
-			if len(deletedPods) != 1 {
-				t.Fatalf("Wrong number of etcd pods on deleted node: %d != 1", len(deletedPods))
-			}
-
 			err = cfg.Client().Resources().Delete(context.TODO(), &nodes.Items[0])
 			if err != nil {
 				t.Fatal(err)
@@ -186,10 +168,6 @@ func TestKubernetes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = wait.For(conditions.New(client.Resources()).ResourceDeleted(&deletedPods[0]), wait.WithTimeout(time.Minute*3))
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			etcdCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
 			members, err = etcd.MemberList(etcdCtx)
@@ -197,8 +175,8 @@ func TestKubernetes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(members.Members) != 2 {
-				t.Fatalf("Wrong number of etcd members: %d != 2", len(members.Members))
+			if len(members.Members) != nNodes-1 {
+				t.Fatalf("Wrong number of final etcd members: %d != %d", len(members.Members), nNodes-1)
 			}
 
 			return ctx


### PR DESCRIPTION
This tests that nodes are synced correctly if missing on startup, rather than just if they are deleted while `etcdmon` is running.