### PR TITLE
Add etcd members for new nodes

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -72,4 +73,8 @@ func (c EtcdClient) MemberList(ctx context.Context) (*etcd.MemberListResponse, e
 
 func (c EtcdClient) MemberRemove(ctx context.Context, id uint64) (*etcd.MemberRemoveResponse, error) {
 	return c.client.Cluster.MemberRemove(ctx, id)
+}
+
+func (c EtcdClient) MemberAdd(ctx context.Context, name string) (*etcd.MemberAddResponse, error) {
+	return c.client.Cluster.MemberAdd(ctx, []string{fmt.Sprintf("https://%s:2380", name)})
 }

--- a/fixtures/kind.yaml
+++ b/fixtures/kind.yaml
@@ -29,3 +29,4 @@ nodes:
   extraPortMappings:
   - containerPort: 2379
     hostPort: 5004
+- role: worker

--- a/k8s.go
+++ b/k8s.go
@@ -32,6 +32,13 @@ func NewController(client *kubernetes.Clientset) *Controller {
 	})
 	informer := cache.NewSharedIndexInformer(watcher, &v1.Node{}, 0, cache.Indexers{})
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(obj)
+			if err == nil {
+				klog.Infof("Adding node %s", key)
+				queue.Add(key)
+			}
+		},
 		DeleteFunc: func(obj interface{}) {
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err == nil {
@@ -162,8 +169,16 @@ func (c *Controller) reconcileEtcd(etcd *EtcdClient, baseCtx context.Context) er
 		}
 	}
 
-	for k := range nodes {
-		klog.Warningf("Did not find etcd member for node %s\n", k)
+	for nodeName := range nodes {
+		// TODO: Check if we would exceed quorum by adding too many nodes
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		klog.V(2).Infof("Adding etcd member for new node %s\n", nodeName)
+		member, err := etcd.MemberAdd(ctx, nodeName)
+		if err != nil {
+			return err
+		}
+		klog.Infof("Added etcd member for new node %s (%x)\n", nodeName, member.Member.ID)
 	}
 	if len(orphanMembers) > len(members.Members)/2 {
 		klog.Errorf("%d out of %d members are missing nodes, which is more than quorum\n", len(orphanMembers), len(members.Members))

--- a/k8s.go
+++ b/k8s.go
@@ -215,16 +215,13 @@ func (c *Controller) handleErr(err error, key interface{}) {
 }
 
 func (c *Controller) EtcdEndpoints() []string {
-	pods := c.podInformer.GetIndexer().List()
+	nodes := c.informer.GetIndexer().List()
 
 	endpoints := []string{}
-	for _, pod := range pods {
-		endpoint, ok := pod.(*v1.Pod).ObjectMeta.Annotations["kubeadm.kubernetes.io/etcd.advertise-client-urls"]
-		if !ok {
-			continue
-		}
+	for _, node := range nodes {
+		endpoint := fmt.Sprintf("https://%s:2379", node.(*v1.Node).ObjectMeta.Name)
 		endpoints = append(endpoints, endpoint)
 	}
-	klog.Infof("Found etcd endpoints %s from pod annotations\n", strings.Join(endpoints, ","))
+	klog.Infof("Found etcd endpoints %s from node names\n", strings.Join(endpoints, ","))
 	return endpoints
 }

--- a/main_test.go
+++ b/main_test.go
@@ -161,14 +161,14 @@ func TestKubernetes(t *testing.T) {
 				}
 			}
 			var err error
-			// Without retries, timeouts are exceeded (even if the timeout is
-			// longer). Probably due to etcd member being removed.
-			for i := 0; i < 2; i++ {
+			// Without retries, timeouts are exceeded, with the pod stuck in
+			// ContainerCreating. Possibly due to etcd member being removed.
+			for i := 0; i < 3; i++ {
 				err = wait.For(
 					conditions.New(client.Resources()).DeploymentConditionMatch(
 						&deployment, appsv1.DeploymentAvailable, corev1.ConditionTrue,
 					),
-					wait.WithTimeout(time.Second*15),
+					wait.WithTimeout(time.Second*5),
 				)
 				if err == nil {
 					break


### PR DESCRIPTION
Duplicate of #8, but into `master` this time.

I'm not entirely happy with the state of this, for two reasons:
1. Tests are somewhat flaky
2. Member deletion sometimes fails if the cluster is not fully available

(1) can maybe be worked around by adding/removing `etcd` members, instead of adding/removing nodes. `kind` doesn't work well with changes to the nodes.

(2) I think is due to `etcd` member sync giving up if not all cluster members are healthy. I think we should get the endpoint list from the number of healthy pods/nodes, and not from etcd itself.