### PR TITLE
Remove redundant cache step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,14 +37,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "^1.22.0"
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            go-
       - run: go test -timeout 5m ./...
 
   publish:


### PR DESCRIPTION
The setup-go action now does its own caching, so no need to do it explicitly.