### PR TITLE
Refresh client certificates

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,16 +38,16 @@ func main() {
 		panic(err.Error())
 	}
 
-	certs := etcdmon.CertPaths{
+	certs, err := etcdmon.LoadCerts(etcdmon.CertPaths{
 		CaCert:     *caCert,
 		ClientCert: *clientCert,
 		ClientKey:  *clientKey,
-	}
-
-	etcd, err := etcdmon.NewEtcd(certs)
+	})
 	if err != nil {
 		panic(err.Error())
 	}
+
+	etcd := etcdmon.NewEtcd(certs)
 	controller := etcdmon.NewController(clientset, etcd, *namespace, *selector, *timeout)
-	controller.Run(context.Background(), certs, 1)
+	controller.Run(context.Background(), 1)
 }

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 		panic(err.Error())
 	}
 
-	certs, err := etcdmon.LoadCerts(etcdmon.CertPaths{
+	certs, err := etcdmon.LoadCerts(context.Background(), etcdmon.CertPaths{
 		CaCert:     *caCert,
 		ClientCert: *clientCert,
 		ClientKey:  *clientKey,

--- a/pkg/etcdmon/controller.go
+++ b/pkg/etcdmon/controller.go
@@ -82,7 +82,7 @@ func NewController(client kubernetes.Interface, etcd EtcdClient, namespace strin
 	}
 }
 
-func (c *Controller) Run(ctx context.Context, etcdCerts CertPaths, workers int) error {
+func (c *Controller) Run(ctx context.Context, workers int) error {
 	defer runtime.HandleCrash()
 	defer c.queue.ShutDown()
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -2,7 +2,15 @@ package e2e
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 	"testing"
@@ -36,11 +44,78 @@ func TestMain(m *testing.M) {
 	os.Exit(testenv.Run(m))
 }
 
+type certificatePair struct {
+	Cert *x509.Certificate
+	Key  *ecdsa.PrivateKey
+}
+
+func (c *certificatePair) KeyPem() (key string, err error) {
+	encoded, err := x509.MarshalECPrivateKey(c.Key)
+	if err != nil {
+		return "", err
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: encoded})), nil
+}
+
+func (c *certificatePair) CertPem() (key string, err error) {
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.Cert.Raw})), nil
+
+}
+
+func makeCertificate(ca *certificatePair, subject pkix.Name, expiry time.Duration) (*certificatePair, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	maxSerial := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, maxSerial)
+	if err != nil {
+		return nil, err
+	}
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               subject,
+		NotBefore:             time.Now().Add(-1 * time.Minute),
+		NotAfter:              time.Now().Add(expiry),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	var certDer []byte
+	if ca == nil {
+		template.IsCA = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+		certDer, err = x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	} else {
+		certDer, err = x509.CreateCertificate(rand.Reader, template, ca.Cert, &key.PublicKey, ca.Key)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := x509.ParseCertificate(certDer)
+	if err != nil {
+		return nil, err
+	}
+
+	return &certificatePair{Cert: cert, Key: key}, nil
+}
+
+func createCa() func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		ca, err := makeCertificate(nil, pkix.Name{CommonName: "etcd CA"}, 48*time.Hour)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		return context.WithValue(ctx, contextKey("ca"), ca)
+	}
+}
+
 func makeEtcdArgs(name string, replicas int32, start int32, new bool) []string {
 	initialCluster := make([]string, 0, replicas)
 	for i := start; i < start+replicas; i++ {
 		hostname := fmt.Sprintf("%s-%d", name, i)
-		initialCluster = append(initialCluster, fmt.Sprintf("%s=http://%s.%s:2380", hostname, hostname, name))
+		initialCluster = append(initialCluster, fmt.Sprintf("%s=https://%s.%s:2380", hostname, hostname, name))
 	}
 
 	initialState := "new"
@@ -52,10 +127,19 @@ func makeEtcdArgs(name string, replicas int32, start int32, new bool) []string {
 		"--name=$(HOSTNAME)",
 		fmt.Sprintf("--initial-cluster-state=%s", initialState),
 		fmt.Sprintf("--initial-cluster=%s", strings.Join(initialCluster, ",")),
-		"--listen-peer-urls=http://$(POD_IP):2380",
-		"--initial-advertise-peer-urls=http://$(POD_IP):2380",
-		"--listen-client-urls=http://0.0.0.0:2379",
-		"--advertise-client-urls=http://$(POD_IP):2379",
+		"--listen-peer-urls=https://$(POD_IP):2380",
+		"--initial-advertise-peer-urls=https://$(POD_IP):2380",
+		"--listen-client-urls=https://0.0.0.0:2379",
+		"--advertise-client-urls=https://$(POD_IP):2379",
+		"--listen-metrics-urls=http://$(POD_IP):2378",
+		"--client-cert-auth=true",
+		"--trusted-ca-file=/etc/etcd/pki/ca.pem",
+		"--cert-file=/etc/etcd/pki/cert.pem",
+		"--key-file=/etc/etcd/pki/key.pem",
+		"--peer-client-cert-auth=true",
+		"--peer-trusted-ca-file=/etc/etcd/pki/ca.pem",
+		"--peer-cert-file=/etc/etcd/pki/cert.pem",
+		"--peer-key-file=/etc/etcd/pki/key.pem",
 		"--data-dir=/var/lib/etcd",
 	}
 }
@@ -95,6 +179,21 @@ func startEtcd(name string, replicas int32) func(ctx context.Context, t *testing
 
 		labels := map[string]string{"app": "etcd", "instance": name}
 
+		ca := ctx.Value(contextKey("ca")).(*certificatePair)
+		certPem, err := ca.CertPem()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		keyPem, err := ca.KeyPem()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		certSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "ca-cert", Namespace: ns.Name},
+			StringData: map[string]string{"cert.pem": certPem, "key.pem": keyPem},
+		}
+
 		dnsService := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns.Name},
 			Spec: corev1.ServiceSpec{
@@ -106,6 +205,21 @@ func startEtcd(name string, replicas int32) func(ctx context.Context, t *testing
 				},
 			},
 		}
+
+		env := []corev1.EnvVar{{
+			Name: "POD_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+			},
+		}, {
+			Name: "HOSTNAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			},
+		}, {
+			Name:  "SERVICE_NAME",
+			Value: dnsService.Name,
+		}}
 
 		statefulSet := appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns.Name},
@@ -130,17 +244,46 @@ func startEtcd(name string, replicas int32) func(ctx context.Context, t *testing
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{{
+							Name:  "certs",
+							Image: "alpine/openssl:3.3.2",
+							Args: []string{
+								"req", "-x509", "-newkey=ec", "-pkeyopt=ec_paramgen_curve:prime256v1", "-nodes",
+								"-CA=/etc/etcd/ca/cert.pem", "-CAkey=/etc/etcd/ca/key.pem",
+								"-keyout=/etc/etcd/pki/key.pem", "-out=/etc/etcd/pki/cert.pem",
+								"-days=1", "-subj=/CN=etcd",
+								"-addext=subjectAltName=DNS:localhost,DNS:$(HOSTNAME).$(SERVICE_NAME),IP:$(POD_IP),IP:127.0.0.1",
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "ca", MountPath: "/etc/etcd/ca"},
+								{Name: "pki", MountPath: "/etc/etcd/pki"},
+							},
+							Env: env,
+						}, {
+							Name:  "ca",
+							Image: "busybox",
+							Args:  []string{"cp", "/etc/etcd/ca/cert.pem", "/etc/etcd/pki/ca.pem"},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "ca", MountPath: "/etc/etcd/ca"},
+								{Name: "pki", MountPath: "/etc/etcd/pki"},
+							},
+							Env: env,
+						}},
 						Containers: []corev1.Container{{
 							Name:    "etcd",
-							Image:   "registry.k8s.io/etcd:3.5.14-0",
+							Image:   "registry.k8s.io/etcd:3.5.17-0",
 							Command: []string{"etcd"},
 							Args:    makeEtcdArgs(name, replicas, 0, true),
-							Ports:   []corev1.ContainerPort{{Name: "client", ContainerPort: 2379}},
+							Ports: []corev1.ContainerPort{
+								{Name: "client", ContainerPort: 2379},
+								{Name: "metrics", ContainerPort: 2378},
+							},
 							ReadinessProbe: &corev1.Probe{
 								TimeoutSeconds: 15,
 								ProbeHandler: corev1.ProbeHandler{
-									Exec: &corev1.ExecAction{
-										Command: []string{"etcdctl", "member", "list", "--command-timeout=100ms"},
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/readyz",
+										Port: intstr.FromString("metrics"),
 									},
 								},
 							},
@@ -150,23 +293,20 @@ func startEtcd(name string, replicas int32) func(ctx context.Context, t *testing
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/health?serializable=true",
-										Port: intstr.FromString("client"),
+										Port: intstr.FromString("metrics"),
 									},
 								},
 							},
-							VolumeMounts: []corev1.VolumeMount{{Name: "etcd", MountPath: "/var/lib/etcd"}},
-							Env: []corev1.EnvVar{{
-								Name: "POD_IP",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-								},
-							}, {
-								Name: "HOSTNAME",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
-								},
-							}},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "etcd", MountPath: "/var/lib/etcd"},
+								{Name: "pki", MountPath: "/etc/etcd/pki"},
+							},
+							Env: env,
 						}},
+						Volumes: []corev1.Volume{
+							{Name: "pki", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+							{Name: "ca", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certSecret.Name}}},
+						},
 					},
 				},
 			},
@@ -183,7 +323,7 @@ func startEtcd(name string, replicas int32) func(ctx context.Context, t *testing
 			},
 		}
 
-		resources := []k8s.Object{&dnsService, &statefulSet, &service}
+		resources := []k8s.Object{&certSecret, &dnsService, &statefulSet, &service}
 		for _, r := range resources {
 			if err := client.Resources().Create(ctx, r); err != nil {
 				t.Fatal(err)
@@ -235,10 +375,33 @@ func scaleEtcd(name string, replicas int32, start int32) func(ctx context.Contex
 	}
 }
 
-func startEtcdmon(etcdName string) func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+func startEtcdmon(etcdName string, expiry time.Duration) func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client := c.Client()
 		ns := ctx.Value(contextKey("namespace")).(*corev1.Namespace)
+
+		ca := ctx.Value(contextKey("ca")).(*certificatePair)
+		caPem, err := ca.CertPem()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		cert, err := makeCertificate(ca, pkix.Name{CommonName: "etcdmon"}, expiry)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		certPem, err := cert.CertPem()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		keyPem, err := cert.KeyPem()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		certSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "etcdmon-cert", Namespace: ns.Name},
+			StringData: map[string]string{"ca.pem": caPem, "cert.pem": certPem, "key.pem": keyPem},
+		}
 
 		replicas := int32(1)
 		etcdLabels := map[string]string{"app": "etcd", "instance": etcdName}
@@ -271,16 +434,23 @@ func startEtcdmon(etcdName string) func(ctx context.Context, t *testing.T, c *en
 							Args: []string{
 								fmt.Sprintf("--namespace=%s", ns.Name),
 								fmt.Sprintf("--selector=%s", selector.String()),
+								"--ca-cert=/etc/etcdmon/pki/ca.pem",
+								"--client-cert=/etc/etcdmon/pki/cert.pem",
+								"--client-key=/etc/etcdmon/pki/key.pem",
 								"--timeout=5s",
 								"-v=3",
 							},
+							VolumeMounts: []corev1.VolumeMount{{Name: "pki", MountPath: "/etc/etcdmon/pki"}},
 						}},
+						Volumes: []corev1.Volume{
+							{Name: "pki", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: certSecret.Name}}},
+						},
 					},
 				},
 			},
 		}
 
-		resources := []k8s.Object{&role, &roleBinding, &deployment}
+		resources := []k8s.Object{&role, &roleBinding, &deployment, &certSecret}
 		for _, r := range resources {
 			if err := client.Resources().Create(ctx, r); err != nil {
 				t.Fatal(err)
@@ -307,6 +477,12 @@ func waitForEtcd(name string, count int) func(ctx context.Context, t *testing.T,
 		nodePort := ctx.Value(contextKey("nodePort")).(int32)
 		ns := ctx.Value(contextKey("namespace")).(*corev1.Namespace)
 
+		ca := ctx.Value(contextKey("ca")).(*certificatePair)
+		cert, err := makeCertificate(ca, pkix.Name{CommonName: "test-client"}, 1*time.Hour)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
 		etcd := appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns.Name}}
 		if err := wait.For(
 			conditions.New(client.Resources()).ResourceScaled(&etcd, func(object k8s.Object) int32 {
@@ -318,12 +494,18 @@ func waitForEtcd(name string, count int) func(ctx context.Context, t *testing.T,
 			t.Error(err)
 		}
 
-		etcdClient, err := etcdmon.NewEtcd(etcdmon.CertPaths{})
+		caPool := x509.NewCertPool()
+		caPool.AddCert(ca.Cert)
+		tlsConfig := &tls.Config{
+			RootCAs:      caPool,
+			Certificates: []tls.Certificate{{Certificate: [][]byte{cert.Cert.Raw}, PrivateKey: cert.Key}},
+		}
+		etcdClient := etcdmon.NewEtcd(tlsConfig)
 
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = etcdClient.Start(ctx, fmt.Sprintf("http://localhost:%d", nodePort))
+		err = etcdClient.Start(ctx, fmt.Sprintf("https://localhost:%d", nodePort))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -357,49 +539,63 @@ func waitForEtcd(name string, count int) func(ctx context.Context, t *testing.T,
 func TestKubernetes(t *testing.T) {
 	remove := features.New("remove etcd member").
 		WithSetup("create namespace", createNamespace("remove-etcd-test", 30790)).
+		WithSetup("create ca", createCa()).
 		WithTeardown("delete namespace", deleteNamespace()).
 		WithSetup("start etcd", startEtcd("foo", int32(3))).
-		WithSetup("start etcdmon", startEtcdmon("foo")).
+		WithSetup("start etcdmon", startEtcdmon("foo", 1*time.Hour)).
 		WithSetup("remove etcd member", scaleEtcd("foo", 2, 0)).
 		Assess("etcd has correct members", waitForEtcd("foo", 2)).Feature()
 
 	add := features.New("add etcd member").
 		WithSetup("create namespace", createNamespace("add-etcd-test", 30791)).
+		WithSetup("create ca", createCa()).
 		WithTeardown("delete namespace", deleteNamespace()).
 		WithSetup("start etcd", startEtcd("foo", int32(2))).
-		WithSetup("start etcdmon", startEtcdmon("foo")).
+		WithSetup("start etcdmon", startEtcdmon("foo", 1*time.Hour)).
 		WithSetup("add etcd member", scaleEtcd("foo", 3, 0)).
 		Assess("etcd has correct members", waitForEtcd("foo", 3)).Feature()
 
 	replace := features.New("replace etcd member").
 		WithSetup("create namespace", createNamespace("replace-etcd-test", 30792)).
+		WithSetup("create ca", createCa()).
 		WithTeardown("delete namespace", deleteNamespace()).
 		WithSetup("start etcd", startEtcd("foo", int32(3))).
-		WithSetup("start etcdmon", startEtcdmon("foo")).
+		WithSetup("start etcdmon", startEtcdmon("foo", 1*time.Hour)).
 		WithSetup("replace etcd member", scaleEtcd("foo", 3, 1)).
 		Assess("etcd has correct members", waitForEtcd("foo", 3)).Feature()
 
 	removeOnStartup := features.New("remove etcd member on startup").
 		WithSetup("create namespace", createNamespace("startup-remove-etcd-test", 30793)).
+		WithSetup("create ca", createCa()).
 		WithTeardown("delete namespace", deleteNamespace()).
 		WithSetup("start etcd", startEtcd("foo", int32(3))).
 		WithSetup("remove etcd member", scaleEtcd("foo", 2, 0)).
-		WithSetup("start etcdmon", startEtcdmon("foo")).
+		WithSetup("start etcdmon", startEtcdmon("foo", 1*time.Hour)).
 		Assess("etcd has correct members", waitForEtcd("foo", 2)).Feature()
 
 	addOnStartup := features.New("add etcd member on startup").
 		WithSetup("create namespace", createNamespace("startup-add-etcd-test", 30794)).
+		WithSetup("create ca", createCa()).
 		WithSetup("start etcd", startEtcd("foo", int32(2))).
 		WithSetup("add etcd member", scaleEtcd("foo", 3, 0)).
-		WithSetup("start etcdmon", startEtcdmon("foo")).
+		WithSetup("start etcdmon", startEtcdmon("foo", 1*time.Hour)).
 		Assess("etcd has correct members", waitForEtcd("foo", 3)).Feature()
 
 	replaceOnStartup := features.New("replace etcd member on startup").
 		WithSetup("create namespace", createNamespace("startup-replace-etcd-test", 30795)).
+		WithSetup("create ca", createCa()).
 		WithSetup("start etcd", startEtcd("foo", int32(3))).
 		WithSetup("replace etcd member", scaleEtcd("foo", 3, 1)).
-		WithSetup("start etcdmon", startEtcdmon("foo")).
+		WithSetup("start etcdmon", startEtcdmon("foo", 1*time.Hour)).
 		Assess("etcd has correct members", waitForEtcd("foo", 3)).Feature()
 
-	testenv.TestInParallel(t, remove, add, replace, removeOnStartup, addOnStartup, replaceOnStartup)
+	refreshCertificate := features.New("refresh etcd certificate").
+		WithSetup("create namespace", createNamespace("certificate-test", 30796)).
+		WithSetup("create ca", createCa()).
+		WithSetup("start etcd", startEtcd("foo", int32(2))).
+		WithSetup("add etcd member", scaleEtcd("foo", 3, 0)).
+		WithSetup("start etcdmon", startEtcdmon("foo", -1*time.Second)).
+		Assess("etcd has correct members", waitForEtcd("foo", 3)).Feature()
+
+	testenv.TestInParallel(t, remove, add, replace, removeOnStartup, addOnStartup, replaceOnStartup, refreshCertificate)
 }

--- a/tests/e2e/kind.yaml
+++ b/tests/e2e/kind.yaml
@@ -15,3 +15,5 @@ nodes:
     hostPort: 30794
   - containerPort: 30795
     hostPort: 30795
+  - containerPort: 30796
+    hostPort: 30796


### PR DESCRIPTION
If `etcdmon` is running for a long time, the TLS certificates may have expired. Load new certificates for each connection. Could be optimized by watching the certs for changes, but this is fine for now.